### PR TITLE
Fix image ratio on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 There are many [Communication patterns](https://www.objc.io/issues/7-foundation/communication-patterns/)
 
 <div align = "center">
-<img src="https://www.objc.io/images/issue-7/notification-flow-chart-dae4ce12.png" width="500" height="400" />
+<img src="https://www.objc.io/images/issue-7/notification-flow-chart-dae4ce12.png" width="500"/>
 </div>
 
 Sometimes, you just want a unified and quick way to do it. Just call `on` on any `NSObject` subclasses and handle your events the quickest way


### PR DESCRIPTION
Fix ratio for image. In original invalid ratio. I am attach screenshoots:

Original:
<img width="400" alt="Screenshot 2019-05-21 at 11 45 28" src="https://user-images.githubusercontent.com/10995774/58081818-616c4900-7bbe-11e9-9191-0a3ac91a7179.png">

After Pull Request:
<img width="400" alt="Screenshot 2019-05-21 at 11 47 42" src="https://user-images.githubusercontent.com/10995774/58081819-6204df80-7bbe-11e9-9f57-f2897119f48c.png">